### PR TITLE
Update api.py

### DIFF
--- a/rustplus/api/api.py
+++ b/rustplus/api/api.py
@@ -23,6 +23,7 @@ class RustSocket:
         self.playertoken = playertoken
         self.error_checker = ErrorChecker()
         self.responses = {}
+        self.ws = None
 
     def __str__(self) -> str:
         return "RustSocket[ip = {} | port = {} | steamid = {} | playertoken = {}]".format(self.ip, self.port, self.steamid, self.playertoken)


### PR DESCRIPTION
Initialized `ws` in RustSocket class so when raising the error "ClientNotConnectedError" it doesn't throw:
AttributeError: 'RustSocket' object has no attribute 'ws'