### PR TITLE
fix: use class as return type instead of module

### DIFF
--- a/rustplus/api/rust_api.py
+++ b/rustplus/api/rust_api.py
@@ -166,7 +166,7 @@ class RustSocket(BaseRustSocket):
         add_vending_machines: bool = False,
         override_images: dict = None,
         add_grid: bool = False,
-    ) -> Image:
+    ) -> Image.Image:
 
         if override_images is None:
             override_images = {}


### PR DESCRIPTION
VS Codes shows the update now references the right type.

![image](https://user-images.githubusercontent.com/1134201/212501184-6eb6ca95-2af6-4d73-b01e-a59a7f16ed6d.png)

vs

![image](https://user-images.githubusercontent.com/1134201/212501197-cee8d28b-b440-49fe-ad55-1e129b5e59ae.png)
