### PR TITLE
Start making a global ratelimiter

### DIFF
--- a/rustplus/__init__.py
+++ b/rustplus/__init__.py
@@ -13,6 +13,7 @@ from .api.remote.events import (
 )
 from .api.structures import RustMarker
 from .api.remote.fcm_listener import FCMListener
+from .api.remote.ratelimiter import RateLimiter
 from .commands import CommandOptions, Command
 from .exceptions import *
 from .conversation import ConversationFactory, Conversation, ConversationPrompt

--- a/rustplus/api/base_rust_api.py
+++ b/rustplus/api/base_rust_api.py
@@ -233,7 +233,13 @@ class BaseRustSocket:
 
         # reset ratelimiter
         self.remote.ratelimiter.remove(self.server_id)
-        self.remote.ratelimiter.add_socket(self.server_id, self.ratelimit_limit, self.ratelimit_limit, 1, self.ratelimit_refill)
+        self.remote.ratelimiter.add_socket(
+            self.server_id,
+            self.ratelimit_limit,
+            self.ratelimit_limit,
+            1,
+            self.ratelimit_refill,
+        )
         self.remote.conversation_factory = ConversationFactory(self)
         # remove entity events
         EntityEvent.handlers.unregister_all()

--- a/rustplus/api/base_rust_api.py
+++ b/rustplus/api/base_rust_api.py
@@ -114,8 +114,12 @@ class BaseRustSocket:
 
         :return: None
         """
-        EventLoopManager.set_loop(self.event_loop if self.event_loop is not None else asyncio.get_event_loop(),
-                                  self.server_id)
+        EventLoopManager.set_loop(
+            self.event_loop
+            if self.event_loop is not None
+            else asyncio.get_event_loop(),
+            self.server_id,
+        )
 
         try:
             if self.remote.ws is None:
@@ -350,10 +354,13 @@ class BaseRustSocket:
                 EntityEvent.handlers.register(
                     RegisteredListener(
                         eid, (coro, entity_info.response.entityInfo.type)
-                    ), self.server_id
+                    ),
+                    self.server_id,
                 )
 
-            future = asyncio.run_coroutine_threadsafe(get_entity(self, eid), EventLoopManager.get_loop(self.server_id))
+            future = asyncio.run_coroutine_threadsafe(
+                get_entity(self, eid), EventLoopManager.get_loop(self.server_id)
+            )
             future.add_done_callback(entity_event_callback)
 
             return RegisteredListener(eid, coro)

--- a/rustplus/api/base_rust_api.py
+++ b/rustplus/api/base_rust_api.py
@@ -53,6 +53,8 @@ class BaseRustSocket:
         self.seq = 1
         self.command_options = command_options
         self.raise_ratelimit_exception = raise_ratelimit_exception
+        self.ratelimit_limit = ratelimit_limit
+        self.ratelimit_refill = ratelimit_refill
         self.marker_listener = MapEventListener(self)
         self.use_test_server = use_test_server
         self.event_loop = event_loop
@@ -230,7 +232,8 @@ class BaseRustSocket:
         self.remote.use_proxy = use_proxy
 
         # reset ratelimiter
-        self.remote.ratelimiter.reset(self.server_id)
+        self.remote.ratelimiter.remove(self.server_id)
+        self.remote.ratelimiter.add_socket(self.server_id, self.ratelimit_limit, self.ratelimit_limit, 1, self.ratelimit_refill)
         self.remote.conversation_factory = ConversationFactory(self)
         # remove entity events
         EntityEvent.handlers.unregister_all()

--- a/rustplus/api/remote/__init__.py
+++ b/rustplus/api/remote/__init__.py
@@ -1,6 +1,6 @@
 from .rustplus_proto import *
 from .rustws import RustWebsocket
-from .token_bucket import RateLimiter
+from .ratelimiter import RateLimiter
 from .rust_remote_interface import RustRemote
 from .heartbeat import HeartBeat
 from ..remote.events.event_handler import EventHandler

--- a/rustplus/api/remote/events/event_handler.py
+++ b/rustplus/api/remote/events/event_handler.py
@@ -18,9 +18,9 @@ class EventHandler:
 
     def run_entity_event(self, name, app_message, server_id) -> None:
 
-        handlers: Set[RegisteredListener] = EntityEvent.handlers.get_handlers(server_id).get(
-            str(name)
-        )
+        handlers: Set[RegisteredListener] = EntityEvent.handlers.get_handlers(
+            server_id
+        ).get(str(name))
 
         if handlers is None:
             return
@@ -28,7 +28,11 @@ class EventHandler:
         for handler in handlers.copy():
             coro, event_type = handler.data
 
-            self._schedule_event(EventLoopManager.get_loop(server_id), coro, EntityEvent(app_message, event_type))
+            self._schedule_event(
+                EventLoopManager.get_loop(server_id),
+                coro,
+                EntityEvent(app_message, event_type),
+            )
 
     def run_team_event(self, app_message, server_id) -> None:
 
@@ -36,7 +40,9 @@ class EventHandler:
         for handler in handlers.copy():
             coro = handler.data
 
-            self._schedule_event(EventLoopManager.get_loop(server_id), coro, TeamEvent(app_message))
+            self._schedule_event(
+                EventLoopManager.get_loop(server_id), coro, TeamEvent(app_message)
+            )
 
     def run_chat_event(self, app_message, server_id) -> None:
 
@@ -44,12 +50,18 @@ class EventHandler:
         for handler in handlers.copy():
             coro = handler.data
 
-            self._schedule_event(EventLoopManager.get_loop(server_id), coro, ChatEvent(app_message))
+            self._schedule_event(
+                EventLoopManager.get_loop(server_id), coro, ChatEvent(app_message)
+            )
 
     def run_proto_event(self, byte_data: bytes, server_id) -> None:
 
-        handlers: Set[RegisteredListener] = ProtobufEvent.handlers.get_handlers(server_id)
+        handlers: Set[RegisteredListener] = ProtobufEvent.handlers.get_handlers(
+            server_id
+        )
         for handler in handlers.copy():
             coro = handler.data
 
-            self._schedule_event(EventLoopManager.get_loop(server_id), coro, ProtobufEvent(byte_data))
+            self._schedule_event(
+                EventLoopManager.get_loop(server_id), coro, ProtobufEvent(byte_data)
+            )

--- a/rustplus/api/remote/events/event_loop_manager.py
+++ b/rustplus/api/remote/events/event_loop_manager.py
@@ -8,7 +8,10 @@ class EventLoopManager:
 
     @staticmethod
     def get_loop(server_id: ServerID) -> asyncio.AbstractEventLoop:
-        if EventLoopManager._loop is None or EventLoopManager._loop.get(server_id) is None:
+        if (
+            EventLoopManager._loop is None
+            or EventLoopManager._loop.get(server_id) is None
+        ):
             raise RuntimeError("Event loop is not set")
 
         if EventLoopManager._loop.get(server_id).is_closed():

--- a/rustplus/api/remote/events/handler_list.py
+++ b/rustplus/api/remote/events/handler_list.py
@@ -20,13 +20,17 @@ class HandlerList:
     def unregister_all(self) -> None:
         self._handlers.clear()
 
-    def get_handlers(self, server_id: ServerID) -> Dict[ServerID, Set[RegisteredListener]]:
+    def get_handlers(
+        self, server_id: ServerID
+    ) -> Dict[ServerID, Set[RegisteredListener]]:
         return self._handlers.get(server_id, set())
 
 
 class EntityHandlerList(HandlerList):
     def __init__(self) -> None:
-        self._handlers: Dict[ServerID, Dict[str, Set[RegisteredListener]]] = defaultdict(dict)
+        self._handlers: Dict[
+            ServerID, Dict[str, Set[RegisteredListener]]
+        ] = defaultdict(dict)
 
     def unregister(self, listener: RegisteredListener, server_id: ServerID) -> None:
         if listener.listener_id in self._handlers.get(server_id):
@@ -43,7 +47,9 @@ class EntityHandlerList(HandlerList):
         self._handlers.get(server_id).get(listener.listener_id).add(listener)
 
     def has(self, listener: RegisteredListener, server_id: ServerID) -> bool:
-        if server_id in self._handlers and listener.listener_id in self._handlers.get(server_id):
+        if server_id in self._handlers and listener.listener_id in self._handlers.get(
+            server_id
+        ):
             return listener in self._handlers.get(server_id).get(listener.listener_id)
 
         return False

--- a/rustplus/api/remote/events/map_event_listener.py
+++ b/rustplus/api/remote/events/map_event_listener.py
@@ -42,7 +42,8 @@ class MapEventListener:
             try:
 
                 future = asyncio.run_coroutine_threadsafe(
-                    self.api.get_markers(), EventLoopManager.get_loop(self.api.server_id)
+                    self.api.get_markers(),
+                    EventLoopManager.get_loop(self.api.server_id),
                 )
                 new_highest_id = 0
                 for marker in future.result():
@@ -80,7 +81,8 @@ class MapEventListener:
     def call_event(self, marker, is_new) -> None:
         for listener in self.listeners:
             asyncio.run_coroutine_threadsafe(
-                listener.get_coro()(MarkerEvent(marker, is_new)), EventLoopManager.get_loop(self.api.server_id)
+                listener.get_coro()(MarkerEvent(marker, is_new)),
+                EventLoopManager.get_loop(self.api.server_id),
             ).result()
 
 

--- a/rustplus/api/remote/ratelimiter.py
+++ b/rustplus/api/remote/ratelimiter.py
@@ -1,5 +1,6 @@
 import math
 import time
+import threading
 
 from ...exceptions.exceptions import RateLimitError
 
@@ -33,6 +34,14 @@ class TokenBucket:
 
 
 class RateLimiter:
+
+    @classmethod
+    def default(cls) -> "RateLimiter":
+        """
+        Returns a default rate limiter with 3 tokens per second
+        """
+        return cls(25, 25, 1, 3)
+
     def __init__(
         self, current: int, maximum: int, refresh_rate, refresh_amount
     ) -> None:
@@ -42,40 +51,51 @@ class RateLimiter:
             refresh_rate=refresh_rate,
             refresh_amount=refresh_amount,
         )
-        self.last_consumed = 0
         self.refresh_per_second = self.bucket.refresh_amount / self.bucket.refresh_rate
+        self.lock = threading.Lock()
 
     def can_consume(self, amount: int = 1) -> bool:
         """
         Returns whether the user can consume the amount of tokens provided
         """
+        self.lock.acquire(blocking=True)
         self.bucket.refresh()
-        return self.bucket.can_consume(amount)
+        can_consume = self.bucket.can_consume(amount)
+        self.lock.release()
+        return can_consume
 
     def consume(self, amount: int = 1) -> None:
         """
         Consumes an amount of tokens from the bucket. You should first check to see whether it is possible with can_consume
         """
+        self.lock.acquire(blocking=True)
         self.bucket.refresh()
         if not self.can_consume(amount):
+            self.lock.release()
             raise RateLimitError("Not Enough Tokens")
         self.bucket.consume(amount)
+        self.lock.release()
 
     def get_estimated_delay_time(self, target_cost: int) -> float:
         """
         Returns how long until the amount of tokens needed will be available
         """
-        return (
+        self.lock.acquire(blocking=True)
+        val = (
             math.ceil(
                 (((target_cost - self.bucket.current) / self.refresh_per_second) + 0.1)
                 * 100
             )
             / 100
         )
+        self.lock.release()
+        return val
 
     def reset(self) -> None:
         """
         Resets the limiter, filling the bucket to max.
         """
+        self.lock.acquire(blocking=True)
         self.bucket.last_update = time.time()
         self.bucket.current = self.bucket.max
+        self.lock.release()

--- a/rustplus/api/remote/ratelimiter.py
+++ b/rustplus/api/remote/ratelimiter.py
@@ -76,7 +76,10 @@ class RateLimiter:
         self.lock.acquire(blocking=True)
         can_consume = True
 
-        for bucket in [self.socket_buckets.get(server_id), self.server_buckets.get(server_id.get_server_string())]:
+        for bucket in [
+            self.socket_buckets.get(server_id),
+            self.server_buckets.get(server_id.get_server_string()),
+        ]:
             bucket.refresh()
             if not bucket.can_consume(amount):
                 can_consume = False
@@ -89,7 +92,10 @@ class RateLimiter:
         Consumes an amount of tokens from the bucket. You should first check to see whether it is possible with can_consume
         """
         self.lock.acquire(blocking=True)
-        for bucket in [self.socket_buckets.get(server_id), self.server_buckets.get(server_id.get_server_string())]:
+        for bucket in [
+            self.socket_buckets.get(server_id),
+            self.server_buckets.get(server_id.get_server_string()),
+        ]:
             bucket.refresh()
             if not bucket.can_consume(amount):
                 self.lock.release()
@@ -103,7 +109,10 @@ class RateLimiter:
         """
         self.lock.acquire(blocking=True)
         delay = 0
-        for bucket in [self.socket_buckets.get(server_id), self.server_buckets.get(server_id.get_server_string())]:
+        for bucket in [
+            self.socket_buckets.get(server_id),
+            self.server_buckets.get(server_id.get_server_string()),
+        ]:
             val = (
                 math.ceil(
                     (((target_cost - bucket.current) / bucket.refresh_per_second) + 0.1)

--- a/rustplus/api/remote/rust_remote_interface.py
+++ b/rustplus/api/remote/rust_remote_interface.py
@@ -28,6 +28,7 @@ class RustRemote:
         use_proxy: bool = False,
         api=None,
         use_test_server: bool = False,
+        rate_limiter: RateLimiter = None,
     ) -> None:
 
         self.server_id = server_id
@@ -35,8 +36,13 @@ class RustRemote:
         self.ratelimit_limit = ratelimit_limit
         self.ratelimit_refill = ratelimit_refill
         self.use_proxy = use_proxy
-        self.ratelimiter = RateLimiter(
-            ratelimit_limit, ratelimit_limit, 1, ratelimit_refill
+        if isinstance(rate_limiter, RateLimiter):
+            self.ratelimiter = rate_limiter
+        else:
+            self.ratelimiter = RateLimiter.default()
+
+        self.ratelimiter.add_socket(
+            api.server_id, ratelimit_limit, ratelimit_limit, 1, ratelimit_refill
         )
         self.ws = None
         self.websocket_length = websocket_length
@@ -140,22 +146,27 @@ class RustRemote:
 
             # Fully Refill the bucket
 
-            self.ratelimiter.bucket.current = 0
+            self.ratelimiter.buckets.get(self.server_id).current = 0
 
-            while self.ratelimiter.bucket.current < self.ratelimiter.bucket.max:
+            while (
+                self.ratelimiter.buckets.get(self.server_id).current
+                < self.ratelimiter.buckets.get(self.server_id).max
+            ):
                 await asyncio.sleep(1)
-                self.ratelimiter.bucket.refresh()
+                self.ratelimiter.buckets.get(self.server_id).refresh()
 
             # Reattempt the sending with a full bucket
             cost = self.ws.get_proto_cost(app_request)
 
             while True:
 
-                if self.ratelimiter.can_consume(cost):
-                    self.ratelimiter.consume(cost)
+                if self.ratelimiter.can_consume(self.server_id, cost):
+                    self.ratelimiter.consume(self.server_id, cost)
                     break
 
-                await asyncio.sleep(self.ratelimiter.get_estimated_delay_time(cost))
+                await asyncio.sleep(
+                    self.ratelimiter.get_estimated_delay_time(self.server_id, cost)
+                )
 
             await self.send_message(app_request)
             response = await self.get_response(seq, app_request)

--- a/rustplus/api/remote/rust_remote_interface.py
+++ b/rustplus/api/remote/rust_remote_interface.py
@@ -146,14 +146,14 @@ class RustRemote:
 
             # Fully Refill the bucket
 
-            self.ratelimiter.buckets.get(self.server_id).current = 0
+            self.ratelimiter.socket_buckets.get(self.server_id).current = 0
 
             while (
-                self.ratelimiter.buckets.get(self.server_id).current
-                < self.ratelimiter.buckets.get(self.server_id).max
+                self.ratelimiter.socket_buckets.get(self.server_id).current
+                < self.ratelimiter.socket_buckets.get(self.server_id).max
             ):
                 await asyncio.sleep(1)
-                self.ratelimiter.buckets.get(self.server_id).refresh()
+                self.ratelimiter.socket_buckets.get(self.server_id).refresh()
 
             # Reattempt the sending with a full bucket
             cost = self.ws.get_proto_cost(app_request)

--- a/rustplus/api/remote/rust_remote_interface.py
+++ b/rustplus/api/remote/rust_remote_interface.py
@@ -5,7 +5,7 @@ import time
 from .events.event_handler import EventHandler
 from .rustplus_proto import AppRequest, AppMessage
 from .rustws import RustWebsocket, CONNECTED, PENDING_CONNECTION
-from .token_bucket import RateLimiter
+from .ratelimiter import RateLimiter
 from .expo_bundle_handler import MagicValueGrabber
 from ...utils import ServerID
 from ...conversation import ConversationFactory
@@ -140,7 +140,6 @@ class RustRemote:
 
             # Fully Refill the bucket
 
-            self.ratelimiter.last_consumed = time.time()
             self.ratelimiter.bucket.current = 0
 
             while self.ratelimiter.bucket.current < self.ratelimiter.bucket.max:

--- a/rustplus/api/remote/rustws.py
+++ b/rustplus/api/remote/rustws.py
@@ -163,7 +163,8 @@ class RustWebsocket(websocket.WebSocket):
                         f"{datetime.now().strftime('%d/%m/%Y %H:%M:%S')} [RustPlus.py] Connection interrupted, Retrying"
                     )
                     asyncio.run_coroutine_threadsafe(
-                        self.connect(ignore_open_value=True), EventLoopManager.get_loop(self.server_id)
+                        self.connect(ignore_open_value=True),
+                        EventLoopManager.get_loop(self.server_id),
                     ).result()
                     continue
                 return
@@ -194,7 +195,9 @@ class RustWebsocket(websocket.WebSocket):
             # This means that an entity has changed state
 
             self.remote.event_handler.run_entity_event(
-                app_message.broadcast.entityChanged.entityId, app_message, self.server_id
+                app_message.broadcast.entityChanged.entityId,
+                app_message,
+                self.server_id,
             )
 
         elif self.is_team_broadcast(app_message):

--- a/rustplus/api/rust_api.py
+++ b/rustplus/api/rust_api.py
@@ -19,7 +19,7 @@ from .structures import (
     RustItem,
 )
 from .remote.rustplus_proto import *
-from .remote import HeartBeat
+from .remote import HeartBeat, RateLimiter
 from ..commands import CommandOptions
 from ..exceptions import *
 from ..utils import (
@@ -47,6 +47,7 @@ class RustSocket(BaseRustSocket):
         use_proxy: bool = False,
         use_test_server: bool = False,
         event_loop: asyncio.AbstractEventLoop = None,
+        rate_limiter: RateLimiter = None,
     ) -> None:
         super().__init__(
             ip=ip,
@@ -61,6 +62,7 @@ class RustSocket(BaseRustSocket):
             use_proxy=use_proxy,
             use_test_server=use_test_server,
             event_loop=event_loop,
+            rate_limiter=rate_limiter,
         )
 
     async def get_time(self) -> RustTime:

--- a/rustplus/commands/command_handler.py
+++ b/rustplus/commands/command_handler.py
@@ -33,7 +33,7 @@ class CommandHandler:
     def run_command(self, message: RustChatMessage, prefix) -> None:
 
         if prefix == self.command_options.prefix:
-            command = message.message.split(" ")[0][len(prefix):]
+            command = message.message.split(" ")[0][len(prefix) :]
         else:
             command = prefix
 

--- a/rustplus/conversation/conversation.py
+++ b/rustplus/conversation/conversation.py
@@ -55,7 +55,9 @@ class Conversation:
         await self.send_prompt(await self._prompts[0].prompt())
 
     def run_coro(self, coro, args):
-        return asyncio.run_coroutine_threadsafe(coro(*args), EventLoopManager.get_loop(self._api.server_id)).result()
+        return asyncio.run_coroutine_threadsafe(
+            coro(*args), EventLoopManager.get_loop(self._api.server_id)
+        ).result()
 
     def get_answers(self) -> List[str]:
         return self._answers

--- a/rustplus/utils/server_id.py
+++ b/rustplus/utils/server_id.py
@@ -1,5 +1,4 @@
 class ServerID:
-
     def __init__(self, ip, port, player_id, player_token) -> None:
         self.ip = ip
         self.port = port
@@ -16,7 +15,9 @@ class ServerID:
         if not isinstance(o, ServerID):
             return False
 
-        return self.ip == o.ip and \
-            self.port == o.port and \
-            self.player_id == o.player_id and \
-            self.player_token == o.player_token
+        return (
+            self.ip == o.ip
+            and self.port == o.port
+            and self.player_id == o.player_id
+            and self.player_token == o.player_token
+        )

--- a/rustplus/utils/server_id.py
+++ b/rustplus/utils/server_id.py
@@ -8,6 +8,9 @@ class ServerID:
     def __str__(self) -> str:
         return f"{self.ip}:{self.port} {self.player_id} {self.player_token}"
 
+    def get_server_string(self) -> str:
+        return f"{self.ip}:{self.port}"
+
     def __hash__(self):
         return hash(self.__str__())
 


### PR DESCRIPTION
This will *eventually* enable the usage of a global ratelimiter object to be passed around. Logic that still needs to be implemented:

- [x] Identify the ratelimits by server
- [x] Detect IP based ratelimits