### PR TITLE
Re-register all the entities when the connection is attempted

### DIFF
--- a/rustplus/__init__.py
+++ b/rustplus/__init__.py
@@ -21,5 +21,5 @@ from .utils import *
 
 __name__ = "rustplus"
 __author__ = "olijeffers0n"
-__version__ = "5.5.4"
+__version__ = "5.5.5"
 __support__ = "Discord: https://discord.gg/nQqJe8qvP8"

--- a/rustplus/api/base_rust_api.py
+++ b/rustplus/api/base_rust_api.py
@@ -410,6 +410,7 @@ class BaseRustSocket:
                 return True
 
             if EntityEvent.handlers.has(listener, self.server_id):
+                self.remote.tracked_entities.remove(listener.listener_id)
                 EntityEvent.handlers.unregister(listener, self.server_id)
                 return True
 

--- a/rustplus/api/base_rust_api.py
+++ b/rustplus/api/base_rust_api.py
@@ -233,6 +233,7 @@ class BaseRustSocket:
         self.raise_ratelimit_exception = raise_ratelimit_exception
 
         self.remote.pending_entity_subscriptions = []
+        self.remote.tracked_entities = set()
         self.remote.server_id = ServerID(ip, port, steam_id, player_token)
 
         # reset ratelimiter

--- a/rustplus/api/remote/rust_remote_interface.py
+++ b/rustplus/api/remote/rust_remote_interface.py
@@ -206,13 +206,13 @@ class RustRemote:
             )
 
         future = asyncio.run_coroutine_threadsafe(
-            self.__subscribe_to_entity(entity_id), EventLoopManager.get_loop(self.server_id)
+            self.__subscribe_to_entity(entity_id, True), EventLoopManager.get_loop(self.server_id)
         )
         future.add_done_callback(entity_event_callback)
 
         self.tracked_entities.add(entity_id)
 
-    def __subscribe_to_entity(self, eid: int) -> AppMessage:
+    def __subscribe_to_entity(self, eid: int, return_data: bool) -> AppMessage:
 
         await self.api._handle_ratelimit()
 
@@ -222,6 +222,7 @@ class RustRemote:
 
         await self.send_message(app_request)
 
-        return await self.get_response(
-            app_request.seq, app_request, False
-        )
+        if return_data:
+            return await self.get_response(
+                app_request.seq, app_request, False
+            )

--- a/rustplus/api/remote/rustws.py
+++ b/rustplus/api/remote/rustws.py
@@ -117,6 +117,9 @@ class RustWebsocket(websocket.WebSocket):
             )
             self.thread.start()
 
+        for entity in self.remote.tracked_entities:
+            self.remote.__subscribe_to_entity(entity)
+
     def close(self) -> None:
 
         self.connection_status = CLOSING

--- a/rustplus/api/remote/rustws.py
+++ b/rustplus/api/remote/rustws.py
@@ -118,7 +118,7 @@ class RustWebsocket(websocket.WebSocket):
             self.thread.start()
 
         for entity in self.remote.tracked_entities:
-            self.remote.__subscribe_to_entity(entity)
+            self.remote.__subscribe_to_entity(entity, False)
 
     def close(self) -> None:
 


### PR DESCRIPTION
When the connection is re-attempted to the server, this will re-register all the subscriptions for entity events.

Draft cause its a WIP. If there are a lot of entities, this could be very expensive.