### PR TITLE
Fix type conversion issues in BaseRustSocket constructor

### DIFF
--- a/rustplus/api/base_rust_api.py
+++ b/rustplus/api/base_rust_api.py
@@ -46,6 +46,16 @@ class BaseRustSocket:
         if player_token is None:
             raise ValueError("PlayerToken cannot be None")
 
+        try:
+            steam_id = int(steam_id)
+        except ValueError:
+            raise ValueError("SteamID must be an integer")
+
+        try:
+            player_token = int(player_token)
+        except ValueError:
+            raise ValueError("PlayerToken must be an integer")
+
         self.server_id = ServerID(ip, port, steam_id, player_token)
         self.seq = 1
         self.command_options = command_options


### PR DESCRIPTION
If you create the RustSocket object with the `steamid` and `playertoken` args as strings, it successfully constructs, but in most cases will cause a very hard to diagnose error or will just fail to connect.

This PR fixes that by requiring the user to pass in an int or int-like object.