### PR TITLE
Using shlex.split instead of pythons own split.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ requests
 numpy
 scipy
 betterproto==2.0.0b6
+shlex

--- a/rustplus/commands/command_handler.py
+++ b/rustplus/commands/command_handler.py
@@ -1,4 +1,5 @@
 import asyncio
+import shlex
 from datetime import datetime
 
 from . import Command, CommandTime
@@ -35,7 +36,7 @@ class CommandHandler:
                     message.steam_id,
                     CommandTime(datetime.utcfromtimestamp(message.time), message.time),
                     command,
-                    message.message.split(" ")[1:],
+                    shlex.split(message.message),
                 )
             )
         else:
@@ -52,7 +53,7 @@ class CommandHandler:
                                 datetime.utcfromtimestamp(message.time), message.time
                             ),
                             command,
-                            message.message.split(" ")[1:],
+                            shlex.split(message.message),
                         ),
                     )
                     break

--- a/rustplus/commands/command_handler.py
+++ b/rustplus/commands/command_handler.py
@@ -23,7 +23,7 @@ class CommandHandler:
 
     async def run_command(self, message: RustChatMessage, prefix) -> None:
         if prefix == self.command_options.prefix:
-            command = message.message.split(" ")[0][len(prefix) :]
+            command = shlex.split(message.message)[0][len(prefix) :]
         else:
             command = prefix
 

--- a/rustplus/commands/command_handler.py
+++ b/rustplus/commands/command_handler.py
@@ -36,7 +36,7 @@ class CommandHandler:
                     message.steam_id,
                     CommandTime(datetime.utcfromtimestamp(message.time), message.time),
                     command,
-                    shlex.split(message.message),
+                    shlex.split(message.message)[1:],
                 )
             )
         else:
@@ -53,7 +53,7 @@ class CommandHandler:
                                 datetime.utcfromtimestamp(message.time), message.time
                             ),
                             command,
-                            shlex.split(message.message),
+                            shlex.split(message.message)[1:],
                         ),
                     )
                     break


### PR DESCRIPTION
Shlex.split:
`>>> shlex.split("this is 'my string' that --has=arguments -or=something")
['this', 'is', 'my string', 'that', '--has=arguments', '-or=something']`

Pythons own split:
`>>> "this is 'my string' that --has=arguments -or=something".split(" ")
['this', 'is', "'my", "string'", 'that', '--has=arguments', '-or=something']`

Basically shlex.split is better in my opinion also used by discord.py please fix if any errors i made.