### PR TITLE
Add hash method for RustMarker

### DIFF
--- a/rustplus/api/structures/rust_marker.py
+++ b/rustplus/api/structures/rust_marker.py
@@ -185,3 +185,6 @@ class RustMarker(Serializable):
                 self._out_of_stock,
             )
         )
+    
+    def __hash__(self) -> int:
+        return hash((self._id, self._type))

--- a/rustplus/api/structures/rust_marker.py
+++ b/rustplus/api/structures/rust_marker.py
@@ -185,6 +185,6 @@ class RustMarker(Serializable):
                 self._out_of_stock,
             )
         )
-    
+
     def __hash__(self) -> int:
         return hash((self._id, self._type))


### PR DESCRIPTION
Would be convenient if RustMarker were hashable - trying to store RustMarker as a dictionary key.