### PR TITLE
Improve websocket stability, timeouts and logging

### DIFF
--- a/rustplus/remote/websocket/ws.py
+++ b/rustplus/remote/websocket/ws.py
@@ -1,7 +1,7 @@
 import shlex
 import base64
 import betterproto
-from websockets.exceptions import InvalidURI, InvalidHandshake, ConnectionClosedError
+from websockets.exceptions import InvalidURI, InvalidHandshake, ConnectionClosedError, ConnectionClosedOK
 from websockets.legacy.client import WebSocketClientProtocol
 from websockets.client import connect
 from asyncio import TimeoutError, Task, AbstractEventLoop
@@ -64,7 +64,8 @@ class RustWebsocket:
             self.connection = await connect(
                 address,
                 close_timeout=0,
-                ping_interval=None,
+                ping_interval=20,
+                ping_timeout=10,
                 max_size=1_000_000_000,
             )
         except (InvalidURI, OSError, InvalidHandshake, TimeoutError) as err:
@@ -97,9 +98,13 @@ class RustWebsocket:
             self.connection = None
 
     async def run(self) -> None:
+        RECV_TIMEOUT = 30
+
         while self.open:
             try:
-                data = await self.connection.recv()
+                data = await asyncio.wait_for(
+                    self.connection.recv(), timeout=RECV_TIMEOUT
+                )
 
                 await self.run_coroutine_non_blocking(
                     self.run_proto_event(data, self.server_details)
@@ -111,15 +116,24 @@ class RustWebsocket:
                 app_message = AppMessage()
                 app_message.parse(data)
 
-            except ConnectionClosedError as e:
+            except asyncio.TimeoutError:
+                self.logger.warning(
+                    "WebSocket recv timeout (%s), closing connection",
+                    RECV_TIMEOUT,
+                )
+                break
+
+            except ConnectionClosedOK:
                 if self.debug:
-                    self.logger.exception("Connection Interrupted: %s", e)
-                else:
-                    self.logger.warning("Connection Interrupted: %s", e)
+                    self.logger.info("WebSocket connection closed normally")
+                break
+
+            except ConnectionClosedError as e:
+                self.logger.warning("Connection Interrupted: %s", e)
                 break
 
             except Exception as e:
-                self.logger.exception(
+                self.logger.error(
                     "An Error occurred whilst parsing the message from the server: %s",
                     e,
                 )
@@ -128,7 +142,7 @@ class RustWebsocket:
             try:
                 await self.run_coroutine_non_blocking(self.handle_message(app_message))
             except Exception as e:
-                self.logger.exception(
+                self.logger.error(
                     "An Error occurred whilst handling the message from the server %s",
                     e,
                 )


### PR DESCRIPTION
This PR improves websocket reliability and reduces resource usage.

Added websocket keepalive:
- ping_interval=20
- ping_timeout=10

Added recv timeout (30s) to prevent hanging connections
Handle asyncio.TimeoutError and close stale connections
Handle ConnectionClosedOK (normal close)
Reduced logging overhead:
replaced logger.exception with logger.error
removed unnecessary traceback logging
Simplified connection error handling

Why?
Between rust server restarts the ws sends a huge amount of logs (even if supressed in logger - it takes CPU).
This causes big CPU spikes when you waiting for rust server to restarts (usually happens every day).
This fix resolves that behaivour  

Previously:
websocket could hang indefinitely on recv()
dead connections were not detected
excessive traceback logging increased CPU usage !!!

Now:
stale connections are detected and closed
keepalive ensures connection health
logging is lighter and cleaner

I have it tested on my server with py-spy - difference is about 4400 samples without fix vs 40 samples with fix
Also you can see on grafana graph that is CPU usage now is not even going up between rust server restarts
<img width="732" height="345" alt="image" src="https://github.com/user-attachments/assets/85e2a008-e8a2-4aa3-a164-f7ec9136c745" />

No breaking changes.