### PR TITLE
fix token refill speed mismatch

### DIFF
--- a/rustplus/remote/ratelimiter/__init__.py
+++ b/rustplus/remote/ratelimiter/__init__.py
@@ -34,8 +34,8 @@ class TokenBucket:
 
 
 class RateLimiter:
-    SERVER_LIMIT = 50
-    SERVER_REFRESH_AMOUNT = 15
+    SERVER_LIMIT = 25
+    SERVER_REFRESH_AMOUNT = 3
 
     @classmethod
     def default(cls) -> "RateLimiter":


### PR DESCRIPTION
The documentation states:

> 50 tokens max per IP address with 15 replenished per second and 25 tokens max per PlayerID with 3 replenished per second. 

This ratelimiter is used as default for `RustSocket`, so it should use 25 + 3 per sec instead of 50 + 15 per sec